### PR TITLE
Revert e1dda2a

### DIFF
--- a/data/tt-rss-feedreader-plugin/api_feedreader/init.php
+++ b/data/tt-rss-feedreader-plugin/api_feedreader/init.php
@@ -20,7 +20,7 @@ class Api_feedreader extends Plugin {
 	function init($host)
 	{
 		$this->host = $host;
-		$this->dbh = $host->get_dbh();
+		$this->dbh = $host->get_pdo();
 		$this->host->add_api_method("addLabel", $this);
 		$this->host->add_api_method("removeLabel", $this);
 		$this->host->add_api_method("renameLabel", $this);


### PR DESCRIPTION
e1dda2a causes warning:
````
Legacy connect requested to pgsql
````
Since the upstream [has fixed their issue](https://gitlab.com/demogv/tt-rss/-/commit/208e02c47d086b67f1431a9e09c76a8129ac8939) that killed tt-rss, it's a good time to revert that change.
